### PR TITLE
globals removed from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "url" : "https://github.com/clocasto/pathwizard.git"
   },
   "scripts": {
-    "test": "mocha tests/",
-    "cover:prod": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- tests",
-    "cover:dev": "istanbul cover ./node_modules/mocha/bin/_mocha -- tests && open coverage/lcov-report/index.html",
+    "test": "./node_modules/mocha/bin/_mocha tests/",
+    "cover:prod": "node node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha --report lcovonly -- tests",
+    "cover:dev": "node node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- tests && open coverage/lcov-report/index.html",
     "test-travis": "npm run transpile && npm run cover:prod",
-    "transpile": "babel src --out-file dist/index.js --presets=es2015"
+    "transpile": "node node_modules/babel-cli/bin/babel.js src --out-file dist/index.js --presets=es2015"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
removed global commands from package.json scripts.  This will allow people who don't want to install mocha, istanbul, or babel globally to use the scripts, as well as let us tightly control what version of those programs we want to run, so that future releases don't break something without us knowing about it.