### PR TITLE
Release 1.0.3

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -16,7 +16,6 @@ if (require.cache && __filename) delete require.cache[__filename];
 
 function PathWizardModule() {
   var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-  var func = arguments[1];
 
   if (options.root && typeof options.root !== 'string') throw new Error('PathWizard constructor only accepts undefined or a string-typed project directory.');
   var _PathWizard = new PathWizard(options);
@@ -152,6 +151,7 @@ var PathWizard = function () {
     key: 'ignore',
     value: function ignore(expressions) {
       ignorePath(expressions, this.ignored);
+      this.nodes = traverse(this.root, this.ignored);
       return proxifyPathWizard(this);
     }
 
@@ -166,6 +166,7 @@ var PathWizard = function () {
     key: 'unignore',
     value: function unignore(expressions) {
       unignorePath(expressions, this.ignored);
+      this.nodes = traverse(this.root, this.ignored);
       return proxifyPathWizard(this);
     }
   }]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pathwizard",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A lightweight wrapper around `require` which finds modules and files based on the shortest unique path.",
   "main": "dist/index.js",
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-pathwizard [![Build Status](https://travis-ci.org/clocasto/pathwizard.svg?branch=master)](https://travis-ci.org/clocasto/PathWizard) [![Coverage Status](https://coveralls.io/repos/github/clocasto/PathWizard/badge.svg?branch=master&version=1_0_2)](https://coveralls.io/github/clocasto/PathWizard?branch=master)
+pathwizard [![Build Status](https://travis-ci.org/clocasto/pathwizard.svg?branch=master)](https://travis-ci.org/clocasto/PathWizard) [![Coverage Status](https://coveralls.io/repos/github/clocasto/PathWizard/badge.svg?branch=master&version=1_0_3)](https://coveralls.io/github/clocasto/PathWizard?branch=master)
 =========
 
 A lightweight wrapper around `require` which finds node modules and files based on the shortest unique path. Instead of hard-coding string literals for relative module paths when using `require`, just specify the shortest, unique segment of a path, and pathwizard will find the correct full path.
@@ -158,5 +158,6 @@ MIT (See license.txt)
 
 ## <a href="release-history"></a>Release History
 
+* [1.0.3](https://github.com/clocasto/pathwizard/pull/20)
 * [1.0.2](https://github.com/clocasto/pathwizard/pull/18)
 * [1.0.1](https://github.com/clocasto/pathwizard/pull/13)

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ module.exports = PathWizardModule;
 //Prevents PathWizard from being cached in require.cache - enables `rel` method functionality
 if (require.cache && __filename) delete require.cache[__filename];
 
-function PathWizardModule(options = {}, func) {
+function PathWizardModule(options = {}) {
   if (options.root && typeof options.root !== 'string') throw new Error('PathWizard constructor only accepts undefined or a string-typed project directory.');
   const _PathWizard = new PathWizard(options);
   return proxifyPathWizard(_PathWizard);
@@ -114,6 +114,7 @@ class PathWizard {
    */
   ignore(expressions) {
     ignorePath(expressions, this.ignored);
+    this.nodes = traverse(this.root, this.ignored);
     return proxifyPathWizard(this);
   }
 
@@ -125,6 +126,7 @@ class PathWizard {
    */
   unignore(expressions) {
     unignorePath(expressions, this.ignored);
+    this.nodes = traverse(this.root, this.ignored);
     return proxifyPathWizard(this);
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -4,8 +4,8 @@ const path = require('path');
 const PathWizard = require('../dist');
 const expect = chai.expect;
 
-let _root,
-  _root_a,
+let _root = path.join(__dirname, './test-folder');
+let _root_a,
   _root_b,
   _root_c,
   _root_routes,
@@ -172,19 +172,19 @@ describe('PathWizard', function() {
     let pw;
 
     beforeEach(() => {
-      pw = PathWizard({ cache: false });
+      pw = PathWizard({ cache: false, root: _root });
     });
 
     it(`Using the 'ignore' method`, function() {
       expect(pw.ignore).to.be.an.instanceof(Function);
 
       const ignoredPaths = pw.ignored;
-      const referenceIngoredPaths = ignoredPaths.slice();
+      const referenceIngoredPaths = ['a', 'b', 'c'];
       expect(ignoredPaths).to.eql(['node_modules', 'bower_components']);
 
-      referenceIngoredPaths.slice().forEach(pw.unignore);
-      expect(ignoredPaths).to.eql([]);
-      referenceIngoredPaths.slice().forEach(pw.ignore);
+      referenceIngoredPaths.forEach(pw.ignore);
+      expect(ignoredPaths).to.eql(['node_modules', 'bower_components', 'a', 'b', 'c']);
+      referenceIngoredPaths.forEach(pw.unignore);
       expect(ignoredPaths).to.eql(['node_modules', 'bower_components']);
     })
 
@@ -194,9 +194,9 @@ describe('PathWizard', function() {
       const ignoredPaths = pw.ignored;
       expect(ignoredPaths).to.eql(['node_modules', 'bower_components']);
 
-      pw.unignore('node_modules');
+      pw.unignore('bower_components');
 
-      expect(ignoredPaths.includes('node_modules')).to.be.false;
+      expect(ignoredPaths.includes('bower_components')).to.be.false;
     })
 
     it(`Without Error if No Results are Found or if the Ignored State is Empty`, function() {
@@ -204,8 +204,6 @@ describe('PathWizard', function() {
       const referenceIngoredPaths = ignoredPaths.slice();
       expect(ignoredPaths).to.eql(['node_modules', 'bower_components']);
 
-      referenceIngoredPaths.forEach(pw.unignore);
-      expect(ignoredPaths).to.eql([]);
       referenceIngoredPaths.forEach(pw.unignore);
       expect(ignoredPaths).to.eql([]);
     })
@@ -224,7 +222,7 @@ describe('PathWizard', function() {
     })
 
     it(`Using the 'ignore' option in the PathWizard constructor`, function() {
-      pw = PathWizard({ cache: false, ignored: [] });
+      pw = PathWizard({ ignored: [], root: _root });
       expect(pw.ignored).to.eql([]);
 
       pw.ignore('node_modules');
@@ -234,7 +232,7 @@ describe('PathWizard', function() {
     })
 
     it(`Chaining a search after the ignore`, function() {
-      pw = PathWizard({ cache: false, ignored: [] });
+      pw = PathWizard({ ignored: [], root: _root });
 
       //This should NOT cause require chai to fail. This should prevent file matches in node_modules/
       const chaiModule = pw.ignore(['node_modules'])('chai');
@@ -250,7 +248,7 @@ describe('PathWizard', function() {
     })
 
     it(`Chaining a search after the unignore`, function() {
-      pw = PathWizard({ cache: false, ignored: ['node_modules', 'a'] });
+      pw = PathWizard({ ignored: ['node_modules', 'a'], root: _root });
 
       //This should NOT cause require chai to fail. This should prevent file matches in node_modules/
       const chaiModule = pw.unignore(['node_modules'])('chai');
@@ -267,7 +265,7 @@ describe('PathWizard', function() {
     })
 
     it(`from arrays of ignore terms`, function() {
-      pw = PathWizard({ cache: false, ignored: [] });
+      pw = PathWizard({ ignored: [], root: _root });
 
       pw.ignore(['node_modules']);
       expect(pw.ignored).to.eql(['node_modules']);
@@ -289,7 +287,7 @@ describe('PathWizard', function() {
     })
 
     it(`won't search in ignored directories`, function() {
-      pw = PathWizard({ cache: false });
+      pw = PathWizard({ root: _root });
 
       pw.ignore(['a', 'b', 'c']);
       expect(pw.ignored).to.eql(['node_modules', 'bower_components', 'a', 'b', 'c']);
@@ -299,7 +297,7 @@ describe('PathWizard', function() {
     })
 
     it(`and can handle incorrect search term types`, function() {
-      pw = PathWizard({ cache: false, ignored: [] });
+      pw = PathWizard({ cache: false, ignored: [], root: _root });
 
       pw.ignore('');
       pw.ignore(['']);
@@ -342,7 +340,7 @@ describe('PathWizard', function() {
   })
 
   describe('Can, For Absolute Paths,', function() {
-    const pw = PathWizard({ cache: false, root: path.join(__dirname, 'test-folder') });
+    const pw = PathWizard({ cache: false, root: _root });
 
     describe('Handle Invalid Arguments', function() {
 


### PR DESCRIPTION
-Correctly fixes ignore and unignore method chaining by forcing pathwizard to re-traverse after invoking either of those methods.